### PR TITLE
Add OpenLayers map with basemap selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Initial project setup with Svelte and Vite.
+- Basic map component using OpenLayers.
+- Sidebar with basemap selection.
+- Basemap options: Esri, Google Street, Google Satellite.
+- State management for basemap selection using Svelte stores.

--- a/src/lib/MapViewer.svelte
+++ b/src/lib/MapViewer.svelte
@@ -24,7 +24,8 @@ const basemaps: Record<string, { label: string; url: string }> = {
 
 onMount(async () => {
   // @ts-ignore - external module without types
-  ol = await import('https://cdn.jsdelivr.net/npm/ol@7.4.0/dist/ol.js');
+  const olModule = await import('https://cdn.jsdelivr.net/npm/ol@7.4.0/dist/ol.js');
+  ol = olModule.default;
   const { Map, View, layer, source, proj } = ol;
   baseLayer = new layer.Tile({
     source: new source.XYZ({

--- a/src/lib/MapViewer.svelte
+++ b/src/lib/MapViewer.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+import { onMount } from 'svelte';
+
+let mapTarget: HTMLDivElement;
+let map: any;
+let baseLayer: any;
+let selected: string = 'esri';
+let ol: any;
+
+const basemaps: Record<string, { label: string; url: string }> = {
+  esri: {
+    label: 'Esri World Imagery',
+    url: 'https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'
+  },
+  gstreets: {
+    label: 'Google Streets',
+    url: 'https://mt{0-3}.google.com/vt/lyrs=m&x={x}&y={y}&z={z}'
+  },
+  gsat: {
+    label: 'Google Satellite',
+    url: 'https://mt{0-3}.google.com/vt/lyrs=s&x={x}&y={y}&z={z}'
+  }
+};
+
+onMount(async () => {
+  // @ts-ignore - external module without types
+  ol = await import('https://cdn.jsdelivr.net/npm/ol@7.4.0/dist/ol.js');
+  const { Map, View, layer, source, proj } = ol;
+  baseLayer = new layer.Tile({
+    source: new source.XYZ({
+      url: basemaps[selected].url
+    })
+  });
+  map = new Map({
+    target: mapTarget,
+    layers: [baseLayer],
+    view: new View({
+      center: proj.fromLonLat([0, 0]),
+      zoom: 2
+    })
+  });
+});
+
+function changeBasemap() {
+  if (baseLayer && ol) {
+    const { source } = ol;
+    baseLayer.setSource(
+      new source.XYZ({
+        url: basemaps[selected].url
+      })
+    );
+  }
+}
+</script>
+
+<div class="controls">
+  <label>
+    Basemap:
+    <select bind:value={selected} on:change={changeBasemap}>
+      {#each Object.entries(basemaps) as [key, bm]}
+        <option value={key}>{bm.label}</option>
+      {/each}
+    </select>
+  </label>
+</div>
+<div bind:this={mapTarget} class="map"></div>
+
+<style>
+.map {
+  width: 100%;
+  height: 80vh;
+}
+.controls {
+  margin-bottom: 0.5rem;
+}
+</style>
+

--- a/src/lib/Sidebar.svelte
+++ b/src/lib/Sidebar.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import { selectedBasemap } from './store';
+
+  const basemaps = {
+    esri: {
+      name: 'Esri',
+    },
+    'google-street': {
+      name: 'Google Street',
+    },
+    'google-satellite': {
+      name: 'Google Satellite',
+    },
+  };
+</script>
+
+<div class="sidebar">
+  <div class="sidebar-content">
+    <h2>Basemap</h2>
+    <select bind:value={$selectedBasemap}>
+      {#each Object.entries(basemaps) as [id, { name }]}
+        <option value={id}>{name}</option>
+      {/each}
+    </select>
+  </div>
+</div>
+
+<style>
+  .sidebar {
+    width: 300px;
+    height: 100%;
+    background-color: #f0f0f0;
+    padding: 1rem;
+    box-sizing: border-box;
+  }
+</style>

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,0 +1,3 @@
+import { writable } from 'svelte/store';
+
+export const selectedBasemap = writable('esri');

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -8,4 +8,18 @@
 	<link rel="icon" href={favicon} />
 </svelte:head>
 
-{@render children?.()}
+<div class="main-container">
+	{@render children?.()}
+</div>
+
+<style>
+	:global(html, body) {
+		height: 100%;
+		margin: 0;
+		padding: 0;
+	}
+
+	.main-container {
+		height: 100%;
+	}
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,2 +1,6 @@
-<h1>Welcome to SvelteKit</h1>
-<p>Visit <a href="https://svelte.dev/docs/kit">svelte.dev/docs/kit</a> to read the documentation</p>
+<script lang="ts">
+  import MapViewer from '$lib/MapViewer.svelte';
+</script>
+
+<MapViewer />
+

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,17 @@
 <script lang="ts">
   import MapViewer from '$lib/MapViewer.svelte';
+  import Sidebar from '$lib/Sidebar.svelte';
 </script>
 
-<MapViewer />
+<main>
+  <Sidebar />
+  <MapViewer />
+</main>
+
+<style>
+  main {
+    display: flex;
+    height: 100%;
+  }
+</style>
 


### PR DESCRIPTION
## Summary
- add interactive MapViewer component powered by OpenLayers
- allow switching between Esri World Imagery, Google Streets and Google Satellite basemaps
- display map viewer on the home page

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bb1f5ad41c832d874b8a4cd59f5bb5